### PR TITLE
Fix for Jobs living forever when attached to the vault-creds sidecar

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,6 +26,8 @@ var (
 	leaseDuration = kingpin.Flag("lease-duration", "Credentials lease duration").Default("1h").Duration()
 
 	jsonOutput = kingpin.Flag("json-log", "Output log in JSON format").Default("false").Bool()
+
+	completedPath = kingpin.Flag("completed-path", "Path where a 'completion' file will be dropped").Default("/tmp/completed").String()
 )
 
 var (
@@ -73,6 +75,9 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	leaseManager := vault.NewLeaseManager(client)
 
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+
 	go func() {
 		log.Printf("renewing %s lease every %s", *leaseDuration, *renewInterval)
 		ticks := time.Tick(*renewInterval)
@@ -90,12 +95,14 @@ func main() {
 				if err != nil {
 					log.Errorf("error renewing db credentials: %s", err)
 				}
+			default:
+				if _, err := os.Stat(*completedPath); err == nil {
+					log.Infof("received completion signal")
+					c <- os.Interrupt
+				}
 			}
 		}
 	}()
-
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
 
 	if *out != "" {
 		file, err := os.OpenFile(*out, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,7 +27,7 @@ var (
 
 	jsonOutput = kingpin.Flag("json-log", "Output log in JSON format").Default("false").Bool()
 
-	completedPath = kingpin.Flag("completed-path", "Path where a 'completion' file will be dropped").Default("/tmp/completed").String()
+	completedPath = kingpin.Flag("completed-path", "Path where a 'completion' file will be dropped").Default("/tmp/vault-creds/completed").String()
 )
 
 var (


### PR DESCRIPTION
Watching for the existence of a completion file into a shared volume to mark that a worker container in the same pod has successfully completed. 

In a short-lived job, the worker container might successfully complete but the vault-creds container will live forever so the job will too. Both the worker container and the vault-creds sidecar should mount the same empty directory – just before the worker finishes it should write a file to indicate it's finished and signalling the vault-creds sidecar to terminate. Should not affect long lived services using vault-creds.

More info here: https://github.com/kubernetes/kubernetes/issues/25908