### PR TITLE
Revoke on exit

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -217,6 +217,9 @@ func main() {
 	}
 
 	<-c
+	if !*initMode {
+		leaseManager.RevokeSelf(ctx, authSecret.Auth.ClientToken)
+	}
 	log.Infof("shutting down")
 	cancel()
 }

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -56,7 +56,7 @@ func (m *DefaultLeaseManager) RenewAuthToken(ctx context.Context, token string, 
 	return err
 }
 
-//RevokeSelf this will attempt to revoke it's own token
+//RevokeSelf this will attempt to revoke its own token
 func (m *DefaultLeaseManager) RevokeSelf(ctx context.Context, token string) {
 
 	err := m.client.Auth().Token().RevokeSelf(token)


### PR DESCRIPTION
This will cause vault-creds to revoke it's own token when it shuts down. I've made this fire and forget as I don't think we should block exit based on this as the token should still get revoked at some point. Unless we think it should?