### PR TITLE
handle lease not found error

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -168,7 +168,7 @@ func main() {
 				if err != nil {
 					log.Errorf("error renewing auth: %s", err)
 				}
-				if err == vault.ErrPermissionDenied {
+				if err == vault.ErrPermissionDenied || err == vault.ErrLeaseNotFound {
 					cleanUp(leasePath, tokenPath)
 					log.Fatal("auth token could no longer be renewed")
 				}
@@ -176,7 +176,7 @@ func main() {
 				if err != nil {
 					log.Errorf("error renewing db credentials: %s", err)
 				}
-				if err == vault.ErrPermissionDenied {
+				if err == vault.ErrPermissionDenied || err == vault.ErrLeaseNotFound {
 					cleanUp(leasePath, tokenPath)
 					log.Fatal("credentials could no longer be renewed")
 				}


### PR DESCRIPTION
Currently vault-creds only properly handles permission denied, you can also get into a state where the database credentials are removed and you will get a "lease not found" error. This pr will allow it to exit and clean up if it gets this error. 