### PR TITLE
set job status check interval to 5 seconds

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -156,7 +156,7 @@ func main() {
 		jobCompletionTicks := time.Tick(10 * time.Second)
 		var status <-chan time.Time
 		if *job {
-			status = time.Tick(5)
+			status = time.Tick(5 * time.Second)
 		}
 		for {
 			select {


### PR DESCRIPTION
This should be set to seconds, this will be going every 5 nanoseconds which isn't ideal