### PR TITLE
fix init bug, where init mode would start renewing creds

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -103,6 +103,11 @@ func main() {
 		leaseExist = true
 	}
 
+	if leaseExist && *initMode {
+		cleanUp(leasePath, tokenPath)
+		log.Fatal("lease detected while in init mode, shutting down and cleaning up")
+	}
+
 	factory := vault.NewKubernetesAuthClientFactory(vaultConfig, kubernetesConfig)
 	client, authSecret, err := factory.Create(tokenPath)
 	if err != nil {


### PR DESCRIPTION
There was a rare edge case where init would generate creds but then exit with failure causing the init container to restart. The init container would then detect the existing creds and renew them like a normal sidecar so your init phase would never end. 

This stops this from happening by deleting the creds file and exiting if it ever gets into this odd state.