### PR TITLE
Docker: Allow vault cert to be validated by public CAs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM scratch
+FROM alpine:3.8
+RUN apk add --no-cache ca-certificates
 
 ADD bin/vaultcreds /vaultcreds
 


### PR DESCRIPTION
Currently because the Docker image is `FROM scratch`, there are no CA certificates available to validate the Vault server's certificate. We are using letsencrypt on our Vault API endpoint so by simply installing the `ca-certificates` package the validation can pass.