### PR TITLE
Remove assumption that there is always a "Username" and "Password" field

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	vaultApi "github.com/hashicorp/vault/api"
 	"github.com/uswitch/vault-creds/pkg/kube"
 	"github.com/uswitch/vault-creds/pkg/vault"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -116,7 +117,7 @@ func main() {
 
 	credsProvider := vault.NewCredentialsProvider(client, *secretPath)
 
-	var creds *vault.Credentials
+	var creds *vaultApi.Secret
 
 	// if there's already a lease, use that and don't generate new credentials
 	if leaseExist {
@@ -177,7 +178,7 @@ func main() {
 					cleanUp(leasePath, tokenPath)
 					log.Fatal("auth token could no longer be renewed")
 				}
-				err = leaseManager.RenewSecret(ctx, creds.Secret, *leaseDuration)
+				err = leaseManager.RenewSecret(ctx, creds, *leaseDuration)
 				if err != nil {
 					log.Errorf("error renewing db credentials: %s", err)
 				}
@@ -213,7 +214,7 @@ func main() {
 		}
 		defer file.Close()
 
-		t.Execute(file, creds)
+		t.Execute(file, creds.Data)
 		log.Printf("wrote credentials to %s", file.Name())
 
 		//write out token
@@ -227,7 +228,7 @@ func main() {
 		log.Printf("wrote token to %s", tokenPath)
 
 		//write out full secret
-		bytes, err := yaml.Marshal(creds)
+		bytes, err := yaml.Marshal(creds.Data)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -241,7 +242,7 @@ func main() {
 			c <- os.Interrupt
 		}
 	} else if !leaseExist {
-		t.Execute(os.Stdout, creds)
+		t.Execute(os.Stdout, creds.Data)
 	}
 
 	<-c

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -20,7 +20,7 @@ var ErrPermissionDenied = errors.New("permission denied")
 var ErrLeaseNotFound = errors.New("lease not found or is not renewable")
 
 type CredentialsProvider interface {
-	Fetch() (*Credentials, error)
+	Fetch() (*api.Secret, error)
 }
 
 type CredentialsRenewer interface {
@@ -114,7 +114,7 @@ func NewCredentialsProvider(client *api.Client, secretPath string) *DefaultCrede
 	return &DefaultCredentialsProvider{client: client, path: secretPath}
 }
 
-func (c *DefaultCredentialsProvider) Fetch() (*Credentials, error) {
+func (c *DefaultCredentialsProvider) Fetch() (*api.Secret, error) {
 	log.Infof("requesting credentials")
 	secret, err := c.client.Logical().Read(c.path)
 	if err != nil {
@@ -123,13 +123,7 @@ func (c *DefaultCredentialsProvider) Fetch() (*Credentials, error) {
 
 	log.WithFields(secretFields(secret)).Infof("succesfully retrieved credentials")
 
-	return &Credentials{secret.Data["username"].(string), secret.Data["password"].(string), secret}, nil
-}
-
-type Credentials struct {
-	Username string
-	Password string
-	Secret   *api.Secret
+	return secret, nil
 }
 
 type TLSConfig struct {


### PR DESCRIPTION
Current behaviour tries to pull the "Username" and "Password" fields
out of the data returned from Vault and sticks them in this custom
"Credentials" struct. This is unnessecary and breaks usage in cases
where the returned secret does not have those fields. (For example
with the AWS secrets engine, you get "access_key" and "secret_key").