### PR TITLE
Refactor

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,11 +3,16 @@ workspace:
   path: src/github.com/uswitch/vault-creds
 
 pipeline:
+  test:
+    image: golang:1.11
+    commands:
+      - go test -v -cover $(go list ./... | grep -v /vendor)
+
   build:
-    image: golang:1.9
+    image: golang:1.11
     commands:
       - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.SHA=${DRONE_COMMIT_SHA}" -o bin/vaultcreds cmd/*.go
-  
+
   docker-latest:
     image: plugins/docker
     repo: quay.io/uswitch/vault-creds
@@ -19,7 +24,7 @@ pipeline:
     when:
       event: push
       branch: master
-  
+
   docker-tagged:
     when:
       event: tag

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -159,12 +159,12 @@ func main() {
 		for {
 			select {
 			case errVal := <-errChan:
-				if errVal == 1 {
+				if errVal == 1 { //something wrong with the lease/token
 					cleanUp(leasePath, tokenPath)
 					log.Fatal("fatal error shutting down")
-				} else if errVal == 2 {
+				} else if errVal == 2 { //something wrong with another container
 					log.Fatal("shutting down")
-				} else if errVal == 0 {
+				} else if errVal == 0 { //other container's have finished
 					c <- os.Interrupt
 				}
 			}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,21 +2,16 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"syscall"
 	"text/template"
-	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/uswitch/vault-creds/pkg/kube"
 	"github.com/uswitch/vault-creds/pkg/vault"
 	"gopkg.in/alecthomas/kingpin.v2"
-	yaml "gopkg.in/yaml.v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 var (
@@ -49,14 +44,6 @@ var (
 var (
 	SHA = ""
 )
-
-func createClientSet(config *rest.Config) (*kubernetes.Clientset, error) {
-	c, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	return c, nil
-}
 
 //This removes the lease and token files in the event of them being expired
 func cleanUp(leasePath, tokenPath string) {
@@ -123,98 +110,61 @@ func main() {
 		log.Fatal("lease detected while in init mode, shutting down and cleaning up")
 	}
 
-	factory := vault.NewKubernetesAuthClientFactory(vaultConfig, kubernetesConfig)
-	client, authSecret, err := factory.Create(tokenPath)
+	var factory vault.ClientFactory
+	if leaseExist {
+		factory = vault.NewFileAuthClientFactory(vaultConfig, tokenPath)
+	} else {
+		factory = vault.NewKubernetesAuthClientFactory(vaultConfig, kubernetesConfig)
+	}
+
+	authClient, err := factory.Create()
 	if err != nil {
 		log.Fatal("error creating client:", err)
 	}
 
-	credsProvider := vault.NewCredentialsProvider(client, *secretPath)
-
-	var creds *vault.Credentials
+	var credsProvider vault.CredentialsProvider
 
 	// if there's already a lease, use that and don't generate new credentials
 	if leaseExist {
-		log.Infof("detected existing lease")
-		bytes, err := ioutil.ReadFile(leasePath)
-		if err != nil {
-			log.Fatal("error reading lease:", err)
-		}
-
-		err = yaml.Unmarshal(bytes, &creds)
-		if err != nil {
-			log.Fatal("error unmarshalling lease")
-		}
-
+		credsProvider = vault.NewFileCredentialsProvider(leasePath)
 	} else {
-		creds, err = credsProvider.Fetch()
-		if err != nil {
-			log.Fatal(err)
-		}
+		credsProvider = vault.NewVaultCredentialsProvider(authClient.Client, *secretPath)
 	}
 
-	config, err := rest.InClusterConfig()
+	creds, err := credsProvider.Fetch()
 	if err != nil {
-		log.Fatalf("error creating kube client config: %s", err)
+		log.Fatalf("failed to retrieve credentials: %v", err)
 	}
 
-	clientSet, err := createClientSet(config)
-	if err != nil {
-		log.Fatalf("error creating kube client: %s", err)
-	}
+	leaseManager := vault.NewLeaseManager(authClient.Client, creds.Secret, *leaseDuration, *renewInterval)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	leaseManager := vault.NewLeaseManager(client)
-
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	signal.Notify(c, syscall.SIGTERM)
 
-	go func() {
-		log.Printf("renewing %s lease every %s", *leaseDuration, *renewInterval)
-		renewTicks := time.Tick(*renewInterval)
-		jobCompletionTicks := time.Tick(10 * time.Second)
-		var status <-chan time.Time
-		if *job {
-			status = time.Tick(5 * time.Second)
+	errChan := make(chan int)
+
+	go leaseManager.Run(ctx, errChan)
+
+	if *job {
+		checker, err := kube.NewKubeChecker(podName, namespace)
+		if err != nil {
+			log.Fatal(err)
 		}
+		go checker.Run(ctx, errChan)
+	}
+
+	go func() {
 		for {
 			select {
-			case <-ctx.Done():
-				log.Infof("stopping renewal")
-				return
-			case <-renewTicks:
-				err := leaseManager.RenewAuthToken(ctx, authSecret.Auth.ClientToken, *leaseDuration)
-				if err != nil {
-					log.Errorf("error renewing auth: %s", err)
-				}
-				if err == vault.ErrPermissionDenied || err == vault.ErrLeaseNotFound {
+			case errVal := <-errChan:
+				if errVal == 1 {
 					cleanUp(leasePath, tokenPath)
-					log.Fatal("auth token could no longer be renewed")
-				}
-				err = leaseManager.RenewSecret(ctx, creds.Secret, *leaseDuration)
-				if err != nil {
-					log.Errorf("error renewing db credentials: %s", err)
-				}
-				if err == vault.ErrPermissionDenied || err == vault.ErrLeaseNotFound {
-					cleanUp(leasePath, tokenPath)
-					log.Fatal("credentials could no longer be renewed")
-				}
-			case <-status:
-				status, err := kube.CheckStatus(clientSet, namespace, podName)
-				if err != nil {
-					log.Errorf("error getting pod status: %s", err)
-				}
-				if status == "Error" {
-					log.Fatal("primary container has errored, shutting down")
-				}
-				if status == "Completed" {
-					log.Infof("received completion signal")
-					c <- os.Interrupt
-				}
-			case <-jobCompletionTicks:
-				if _, err := os.Stat(*completedPath); err == nil {
-					log.Infof("received completion signal")
+					log.Fatal("fatal error shutting down")
+				} else if errVal == 2 {
+					log.Fatal("shutting down")
+				} else if errVal == 0 {
 					c <- os.Interrupt
 				}
 			}
@@ -238,25 +188,17 @@ func main() {
 		t.Execute(file, creds)
 		log.Printf("wrote credentials to %s", file.Name())
 
-		//write out token
-		tokenBytes, err := yaml.Marshal(authSecret)
+		err = authClient.Save(tokenPath)
 		if err != nil {
+			cleanUp(leasePath, tokenPath)
 			log.Fatal(err)
 		}
 
-		ioutil.WriteFile(tokenPath, tokenBytes, 0600)
-
-		log.Printf("wrote token to %s", tokenPath)
-
-		//write out full secret
-		bytes, err := yaml.Marshal(creds)
+		err = creds.Save(leasePath)
 		if err != nil {
+			cleanUp(leasePath, tokenPath)
 			log.Fatal(err)
 		}
-
-		ioutil.WriteFile(leasePath, bytes, 0600)
-
-		log.Printf("wrote lease to %s", leasePath)
 
 		if *initMode {
 			log.Infof("completed init")
@@ -268,7 +210,8 @@ func main() {
 
 	<-c
 	if !*initMode {
-		leaseManager.RevokeSelf(ctx, authSecret.Auth.ClientToken)
+		leaseManager.RevokeSelf(ctx)
+		cleanUp(leasePath, tokenPath)
 	}
 	log.Infof("shutting down")
 	cancel()

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -1,16 +1,47 @@
 package kube
 
 import (
+	"context"
 	"fmt"
+	"time"
 
+	"github.com/cloudflare/cfssl/log"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
-//CheckStatus checks the staus of the other containers
-func CheckStatus(clientSet *kubernetes.Clientset, namespace, podName string) (string, error) {
+type KubeChecker struct {
+	client    *kubernetes.Clientset
+	namespace string
+	podName   string
+}
 
-	pod, err := clientSet.CoreV1().Pods(namespace).Get(podName, v1.GetOptions{})
+func createClientSet(config *rest.Config) (*kubernetes.Clientset, error) {
+	c, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func NewKubeChecker(pod, namespace string) (*KubeChecker, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("error creating kube client config: %s", err)
+	}
+
+	clientSet, err := createClientSet(config)
+	if err != nil {
+		return nil, fmt.Errorf("error creating kube client: %s", err)
+	}
+	return &KubeChecker{client: clientSet, podName: pod, namespace: namespace}, nil
+}
+
+//CheckStatus checks the staus of the other containers
+func (k *KubeChecker) checkStatus() (string, error) {
+
+	pod, err := k.client.CoreV1().Pods(k.namespace).Get(k.podName, v1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("error getting pod: %s", err)
 	}
@@ -22,4 +53,34 @@ func CheckStatus(clientSet *kubernetes.Clientset, namespace, podName string) (st
 	}
 
 	return "", nil
+}
+
+func (k *KubeChecker) Run(ctx context.Context, errChan chan int) {
+	go func() {
+
+		ticker := time.Tick(5 * time.Second)
+
+		for {
+			select {
+			case <-ctx.Done():
+				log.Infof("stopping checker")
+				return
+			case <-ticker:
+				status, err := k.checkStatus()
+				if err != nil {
+					log.Errorf("error getting pod status: %s", err)
+				}
+				if status == "Error" {
+					log.Error("primary container has errored")
+					errChan <- 2
+					return
+				}
+				if status == "Completed" {
+					log.Infof("received completion signal")
+					errChan <- 0
+					return
+				}
+			}
+		}
+	}()
 }

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cloudflare/cfssl/log"
+	log "github.com/Sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"

--- a/pkg/kube/kube_test.go
+++ b/pkg/kube/kube_test.go
@@ -1,0 +1,56 @@
+package kube
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+)
+
+func TestTerminatedReason(t *testing.T) {
+	pod := v1.Pod{Status: v1.PodStatus{
+		ContainerStatuses: []v1.ContainerStatus{
+			v1.ContainerStatus{
+				State: v1.ContainerState{Terminated: &v1.ContainerStateTerminated{
+					Reason: "Completed"}},
+			},
+			v1.ContainerStatus{
+				State: v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+			},
+		}}}
+
+	result := getTerminationReason(&pod)
+	if result != "Completed" {
+		t.Errorf("terminated reason should be Completed got: %v", result)
+	}
+
+	pod = v1.Pod{Status: v1.PodStatus{
+		ContainerStatuses: []v1.ContainerStatus{
+			v1.ContainerStatus{
+				State: v1.ContainerState{Terminated: &v1.ContainerStateTerminated{
+					Reason: "Error"}},
+			},
+			v1.ContainerStatus{
+				State: v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+			},
+		}}}
+
+	result = getTerminationReason(&pod)
+	if result != "Error" {
+		t.Errorf("terminated reason should be Error got: %v", result)
+	}
+
+	pod = v1.Pod{Status: v1.PodStatus{
+		ContainerStatuses: []v1.ContainerStatus{
+			v1.ContainerStatus{
+				State: v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+			},
+			v1.ContainerStatus{
+				State: v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+			},
+		}}}
+
+	result = getTerminationReason(&pod)
+	if result != "" {
+		t.Errorf("terminated reason should be nil got: %v", result)
+	}
+}

--- a/pkg/vault/credentials.go
+++ b/pkg/vault/credentials.go
@@ -1,0 +1,72 @@
+package vault
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/hashicorp/vault/api"
+	yaml "gopkg.in/yaml.v1"
+)
+
+type VaultCredentialsProvider struct {
+	client *api.Client
+	path   string
+}
+
+type FileCredentialsProvider struct {
+	path string
+}
+
+func NewVaultCredentialsProvider(client *api.Client, secretPath string) CredentialsProvider {
+	return &VaultCredentialsProvider{client: client, path: secretPath}
+}
+
+func NewFileCredentialsProvider(path string) CredentialsProvider {
+	return &FileCredentialsProvider{path: path}
+}
+
+func (c *VaultCredentialsProvider) Fetch() (*Credentials, error) {
+	log.Infof("requesting credentials")
+	secret, err := c.client.Logical().Read(c.path)
+	if err != nil {
+		return nil, err
+	}
+
+	log.WithFields(secretFields(secret)).Infof("succesfully retrieved credentials")
+
+	return &Credentials{secret.Data["username"].(string), secret.Data["password"].(string), secret}, nil
+}
+
+func (c *FileCredentialsProvider) Fetch() (*Credentials, error) {
+
+	var creds Credentials
+	log.Infof("detected existing lease")
+	bytes, err := ioutil.ReadFile(c.path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading lease: %v", err)
+	}
+
+	err = yaml.Unmarshal(bytes, &creds)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling lease: %v", err)
+	}
+
+	return &creds, nil
+}
+
+func (c *Credentials) Save(path string) error {
+	//write out full secret
+	bytes, err := yaml.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("error marshalling creds: %v", err)
+	}
+
+	err = ioutil.WriteFile(path, bytes, 0600)
+	if err != nil {
+		return fmt.Errorf("error writing creds to file: %v", err)
+	}
+
+	log.Printf("wrote lease to %s", path)
+	return nil
+}

--- a/pkg/vault/credentials_test.go
+++ b/pkg/vault/credentials_test.go
@@ -1,0 +1,27 @@
+package vault
+
+import (
+	"testing"
+
+	"github.com/hashicorp/vault/api"
+)
+
+func TestCredentials(t *testing.T) {
+	f := FileCredentialsProvider{path: "/tmp/testcreds"}
+
+	secret := api.Secret{Data: map[string]interface{}{"Username": "Bob", "Password": "Foo"}}
+	credentials := Credentials{Secret: &secret}
+	err := credentials.Save("/tmp/testcreds")
+	if err != nil {
+		t.Errorf("error saving testing credentials: %v", err)
+	}
+	creds, err := f.Fetch()
+	if err != nil {
+		t.Errorf("error reading testing credentials: %v", err)
+	}
+
+	if creds.Secret.Data["Username"] != "Bob" || creds.Secret.Data["Password"] != "Foo" {
+		t.Errorf("did not get expected credentials, got username: %v, password: %v", creds.Secret.Data["Username"], creds.Secret.Data["Password"])
+	}
+
+}

--- a/pkg/vault/factory.go
+++ b/pkg/vault/factory.go
@@ -1,0 +1,137 @@
+package vault
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/hashicorp/vault/api"
+	yaml "gopkg.in/yaml.v1"
+)
+
+// KubernetesVaultClientFactory creates a Vault client
+// authenticated against a kubernetes service account
+// token
+type KubernetesVaultClientFactory struct {
+	vault *VaultConfig
+	kube  *KubernetesAuthConfig
+}
+
+type FileVaultClientFactory struct {
+	vault *VaultConfig
+	path  string
+}
+
+type AuthClient struct {
+	Client *api.Client
+	secret *api.Secret
+}
+
+// Create returns a Vault client that has been authenticated
+// with the service account token. It can be used to make other
+// Vault requests
+func (f *KubernetesVaultClientFactory) Create() (*AuthClient, error) {
+	client, err := createUnauthenticatedClient(f.vault)
+	if err != nil {
+		return nil, err
+	}
+
+	var secret *api.Secret
+	secret, err = f.authenticate(client)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AuthClient{Client: client, secret: secret}, nil
+}
+
+func createUnauthenticatedClient(v *VaultConfig) (*api.Client, error) {
+	cfg := api.DefaultConfig()
+	cfg.Address = v.VaultAddr
+	cfg.ConfigureTLS(&api.TLSConfig{CACert: v.TLS.CACert})
+	client, err := api.NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+func (f *FileVaultClientFactory) Create() (*AuthClient, error) {
+	client, err := createUnauthenticatedClient(f.vault)
+	if err != nil {
+		return nil, err
+	}
+
+	var secret *api.Secret
+	log.Info("detected existing vault token, using that")
+	bytes, err := ioutil.ReadFile(f.path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading token:%v", err)
+	}
+
+	err = yaml.Unmarshal(bytes, &secret)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling token: %v", err)
+	}
+
+	client.SetToken(secret.Auth.ClientToken)
+	return &AuthClient{Client: client, secret: secret}, nil
+}
+
+// Exchanges the kubernetes service account token for a vault token
+func (f *KubernetesVaultClientFactory) authenticate(client *api.Client) (*api.Secret, error) {
+	bytes, err := ioutil.ReadFile(f.kube.TokenFile)
+	if err != nil {
+		return nil, fmt.Errorf("error reading token: %s", err)
+	}
+
+	req := client.NewRequest("POST", fmt.Sprintf("/v1/auth/%s", f.kube.LoginPath))
+	req.SetJSONBody(&login{JWT: string(bytes), Role: f.kube.Role})
+	resp, err := client.RawRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Error() != nil {
+		return nil, resp.Error()
+	}
+
+	var secret api.Secret
+	err = json.NewDecoder(resp.Body).Decode(&secret)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing response: %s", err)
+	}
+
+	logger := log.WithFields(secretFields(&secret))
+	logger.Infof("successfully authenticated")
+	client.SetToken(secret.Auth.ClientToken)
+
+	return &secret, nil
+}
+
+func NewKubernetesAuthClientFactory(vault *VaultConfig, kube *KubernetesAuthConfig) ClientFactory {
+	return &KubernetesVaultClientFactory{vault: vault, kube: kube}
+}
+
+func NewFileAuthClientFactory(vault *VaultConfig, path string) ClientFactory {
+	return &FileVaultClientFactory{vault: vault, path: path}
+}
+
+func (a *AuthClient) Save(path string) error {
+	//write out token
+	tokenBytes, err := yaml.Marshal(a.secret)
+	if err != nil {
+		return fmt.Errorf("error marshalling auth secret: %v", err)
+	}
+
+	err = ioutil.WriteFile(path, tokenBytes, 0600)
+	if err != nil {
+		return fmt.Errorf("error writing auth secret to file: %v", err)
+	}
+
+	log.Infof("wrote token to %s", path)
+
+	return nil
+}

--- a/pkg/vault/factory.go
+++ b/pkg/vault/factory.go
@@ -49,7 +49,7 @@ func (f *KubernetesVaultClientFactory) Create() (*AuthClient, error) {
 func createUnauthenticatedClient(v *VaultConfig) (*api.Client, error) {
 	cfg := api.DefaultConfig()
 	cfg.Address = v.VaultAddr
-	cfg.ConfigureTLS(&api.TLSConfig{CACert: v.TLS.CACert})
+	cfg.ConfigureTLS(&api.TLSConfig{CACert: v.TLS.CACert, CAPath: v.TLS.CAPath})
 	client, err := api.NewClient(cfg)
 	if err != nil {
 		return nil, err

--- a/pkg/vault/factory_test.go
+++ b/pkg/vault/factory_test.go
@@ -1,0 +1,26 @@
+package vault
+
+import (
+	"testing"
+
+	"github.com/hashicorp/vault/api"
+)
+
+func TestAuthTokenRead(t *testing.T) {
+	path := "/tmp/testToken"
+	authClient := AuthClient{secret: &api.Secret{Auth: &api.SecretAuth{ClientToken: "foo"}}}
+	err := authClient.Save("/tmp/testToken")
+	if err != nil {
+		t.Errorf("error saving testing credentials: %v", err)
+	}
+
+	factory := FileVaultClientFactory{path: path, vault: &VaultConfig{TLS: &TLSConfig{CACert: "foo"}}}
+	auth, err := factory.Create()
+	if err != nil {
+		t.Errorf("error creating authFactory: %v", err)
+	}
+
+	if auth.Client.Token() != "foo" {
+		t.Errorf("token should be foo got: %v", auth.Client.Token())
+	}
+}

--- a/pkg/vault/manager.go
+++ b/pkg/vault/manager.go
@@ -1,0 +1,122 @@
+package vault
+
+import (
+	"context"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/cenkalti/backoff"
+	"github.com/hashicorp/vault/api"
+)
+
+type DefaultLeaseManager struct {
+	client *api.Client
+	secret *api.Secret
+	lease  time.Duration
+	renew  time.Duration
+}
+
+func (m DefaultLeaseManager) Run(ctx context.Context, c chan int) {
+	go func() {
+
+		log.Printf("renewing %s lease every %s", m.lease, m.renew)
+
+		renewTicks := time.Tick(m.renew)
+
+		for {
+			select {
+			case <-ctx.Done():
+				log.Infof("stopping renewal")
+				return
+			case <-renewTicks:
+				err := m.RenewAuthToken(ctx)
+				if err != nil {
+					log.Errorf("error renewing auth: %s", err)
+				}
+				if err == ErrPermissionDenied || err == ErrLeaseNotFound {
+					//	cleanUp(leasePath, tokenPath)
+					log.Error("auth token could no longer be renewed")
+					c <- 1
+					return
+				}
+				err = m.RenewSecret(ctx)
+				if err != nil {
+					log.Errorf("error renewing db credentials: %s", err)
+				}
+				if err == ErrPermissionDenied || err == ErrLeaseNotFound {
+					//cleanUp(leasePath, tokenPath)
+					log.Error("credentials could no longer be renewed")
+					c <- 1
+					return
+				}
+			}
+		}
+	}()
+
+}
+
+//RevokeSelf this will attempt to revoke its own token
+func (m *DefaultLeaseManager) RevokeSelf(ctx context.Context) {
+
+	err := m.client.Auth().Token().RevokeSelf("")
+	if err != nil {
+		log.Errorf("failed to revoke self: %s", err)
+	} else {
+		log.Infof("revoked own token")
+	}
+
+}
+
+func (m *DefaultLeaseManager) RenewSecret(ctx context.Context) error {
+	logger := log.WithField("leaseID", m.secret.LeaseID)
+	logger.Infof("renewing lease by %s.", m.lease)
+
+	op := func() error {
+		secret, err := m.client.Sys().Renew(m.secret.LeaseID, int(m.lease.Seconds()))
+		if err != nil {
+			logger.Errorf("error renewing lease: %s", err)
+			fatalError := checkFatalError(err)
+			if fatalError != nil {
+				return backoff.Permanent(fatalError)
+			}
+			return err
+		}
+		logger.WithFields(secretFields(secret)).Infof("successfully renewed secret")
+
+		return nil
+	}
+
+	err := backoff.Retry(op, backoff.WithContext(defaultRetryStrategy(m.lease), ctx))
+
+	return err
+}
+
+func NewLeaseManager(client *api.Client, secret *api.Secret, lease time.Duration, renew time.Duration) CredentialsRenewer {
+	return &DefaultLeaseManager{
+		client: client,
+		secret: secret,
+		lease:  lease,
+		renew:  renew,
+	}
+}
+
+func (m *DefaultLeaseManager) RenewAuthToken(ctx context.Context) error {
+	op := func() error {
+		secret, err := m.client.Auth().Token().RenewSelf(int(m.lease.Seconds()))
+		if err != nil {
+			log.Errorf("error renewing token: %s", err)
+			fatalError := checkFatalError(err)
+			if fatalError != nil {
+				return backoff.Permanent(fatalError)
+			}
+			return err
+		}
+		log.WithFields(secretFields(secret)).Infof("successfully renewed auth token")
+
+		return nil
+	}
+
+	err := backoff.Retry(op, backoff.WithContext(defaultRetryStrategy(m.lease), ctx))
+
+	return err
+}

--- a/pkg/vault/manager.go
+++ b/pkg/vault/manager.go
@@ -34,7 +34,6 @@ func (m DefaultLeaseManager) Run(ctx context.Context, c chan int) {
 					log.Errorf("error renewing auth: %s", err)
 				}
 				if err == ErrPermissionDenied || err == ErrLeaseNotFound {
-					//	cleanUp(leasePath, tokenPath)
 					log.Error("auth token could no longer be renewed")
 					c <- 1
 					return
@@ -44,7 +43,6 @@ func (m DefaultLeaseManager) Run(ctx context.Context, c chan int) {
 					log.Errorf("error renewing db credentials: %s", err)
 				}
 				if err == ErrPermissionDenied || err == ErrLeaseNotFound {
-					//cleanUp(leasePath, tokenPath)
 					log.Error("credentials could no longer be renewed")
 					c <- 1
 					return

--- a/pkg/vault/manager.go
+++ b/pkg/vault/manager.go
@@ -29,21 +29,12 @@ func (m DefaultLeaseManager) Run(ctx context.Context, c chan int) {
 				log.Infof("stopping renewal")
 				return
 			case <-renewTicks:
-				err := m.RenewAuthToken(ctx)
+				err := m.Renew(ctx)
 				if err != nil {
-					log.Errorf("error renewing auth: %s", err)
+					log.Errorf("error renewing secret: %s", err)
 				}
 				if err == ErrPermissionDenied || err == ErrLeaseNotFound {
-					log.Error("auth token could no longer be renewed")
-					c <- 1
-					return
-				}
-				err = m.RenewSecret(ctx)
-				if err != nil {
-					log.Errorf("error renewing db credentials: %s", err)
-				}
-				if err == ErrPermissionDenied || err == ErrLeaseNotFound {
-					log.Error("credentials could no longer be renewed")
+					log.Error("secret could no longer be renewed")
 					c <- 1
 					return
 				}
@@ -65,28 +56,58 @@ func (m *DefaultLeaseManager) RevokeSelf(ctx context.Context) {
 
 }
 
-func (m *DefaultLeaseManager) RenewSecret(ctx context.Context) error {
-	logger := log.WithField("leaseID", m.secret.LeaseID)
-	logger.Infof("renewing lease by %s.", m.lease)
+func (m *DefaultLeaseManager) Renew(ctx context.Context) error {
 
 	op := func() error {
-		secret, err := m.client.Sys().Renew(m.secret.LeaseID, int(m.lease.Seconds()))
-		if err != nil {
-			logger.Errorf("error renewing lease: %s", err)
-			fatalError := checkFatalError(err)
-			if fatalError != nil {
-				return backoff.Permanent(fatalError)
-			}
-			return err
-		}
-		logger.WithFields(secretFields(secret)).Infof("successfully renewed secret")
-
-		return nil
+		return renewAuth(m.client, int(m.lease.Seconds()))
 	}
 
 	err := backoff.Retry(op, backoff.WithContext(defaultRetryStrategy(m.lease), ctx))
 
+	if err != nil {
+		return err
+	}
+
+	logger := log.WithField("leaseID", m.secret.LeaseID)
+	logger.Infof("renewing lease by %s.", m.lease)
+
+	op = func() error {
+		return renewSecret(m.client, m.secret.LeaseID, int(m.lease.Seconds()))
+	}
+
+	err = backoff.Retry(op, backoff.WithContext(defaultRetryStrategy(m.lease), ctx))
+
 	return err
+}
+
+func renewAuth(client *api.Client, renew int) error {
+	secret, err := client.Auth().Token().RenewSelf(renew)
+	if err != nil {
+		log.Errorf("error renewing token: %s", err)
+		fatalError := checkFatalError(err)
+		if fatalError != nil {
+			return backoff.Permanent(fatalError)
+		}
+		return err
+	}
+	log.WithFields(secretFields(secret)).Infof("successfully renewed auth token")
+
+	return nil
+}
+
+func renewSecret(client *api.Client, leaseID string, renew int) error {
+	secret, err := client.Sys().Renew(leaseID, renew)
+	if err != nil {
+		log.Errorf("error renewing lease: %s", err)
+		fatalError := checkFatalError(err)
+		if fatalError != nil {
+			return backoff.Permanent(fatalError)
+		}
+		return err
+	}
+	log.WithFields(secretFields(secret)).Infof("successfully renewed secret")
+
+	return nil
 }
 
 func NewLeaseManager(client *api.Client, secret *api.Secret, lease time.Duration, renew time.Duration) CredentialsRenewer {
@@ -96,25 +117,4 @@ func NewLeaseManager(client *api.Client, secret *api.Secret, lease time.Duration
 		lease:  lease,
 		renew:  renew,
 	}
-}
-
-func (m *DefaultLeaseManager) RenewAuthToken(ctx context.Context) error {
-	op := func() error {
-		secret, err := m.client.Auth().Token().RenewSelf(int(m.lease.Seconds()))
-		if err != nil {
-			log.Errorf("error renewing token: %s", err)
-			fatalError := checkFatalError(err)
-			if fatalError != nil {
-				return backoff.Permanent(fatalError)
-			}
-			return err
-		}
-		log.WithFields(secretFields(secret)).Infof("successfully renewed auth token")
-
-		return nil
-	}
-
-	err := backoff.Retry(op, backoff.WithContext(defaultRetryStrategy(m.lease), ctx))
-
-	return err
 }

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -2,18 +2,14 @@ package vault
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/cenkalti/backoff"
 	api "github.com/hashicorp/vault/api"
-	yaml "gopkg.in/yaml.v1"
 )
 
 var ErrPermissionDenied = errors.New("permission denied")
@@ -24,17 +20,14 @@ type CredentialsProvider interface {
 }
 
 type CredentialsRenewer interface {
-	RenewSecret(ctx context.Context, secret *api.Secret, lease time.Duration) error
-	RenewAuthToken(ctx context.Context, token string, lease time.Duration) error
-	RevokeSelf(ctx context.Context, token string)
+	RenewSecret(ctx context.Context) error
+	RenewAuthToken(ctx context.Context) error
+	RevokeSelf(ctx context.Context)
+	Run(ctx context.Context, c chan int)
 }
 
 type ClientFactory interface {
-	Create() (*api.Client, *api.Secret, error)
-}
-
-type DefaultLeaseManager struct {
-	client *api.Client
+	Create() (*AuthClient, error)
 }
 
 func defaultRetryStrategy(max time.Duration) backoff.BackOff {
@@ -42,88 +35,6 @@ func defaultRetryStrategy(max time.Duration) backoff.BackOff {
 	strategy.InitialInterval = time.Millisecond * 500
 	strategy.MaxElapsedTime = max
 	return strategy
-}
-
-func (m *DefaultLeaseManager) RenewAuthToken(ctx context.Context, token string, lease time.Duration) error {
-	op := func() error {
-		secret, err := m.client.Auth().Token().RenewSelf(int(lease.Seconds()))
-		if err != nil {
-			log.Errorf("error renewing token: %s", err)
-			fatalError := checkFatalError(err)
-			if fatalError != nil {
-				return backoff.Permanent(fatalError)
-			}
-			return err
-		}
-		log.WithFields(secretFields(secret)).Infof("successfully renewed auth token")
-
-		return nil
-	}
-
-	err := backoff.Retry(op, backoff.WithContext(defaultRetryStrategy(lease), ctx))
-
-	return err
-}
-
-//RevokeSelf this will attempt to revoke its own token
-func (m *DefaultLeaseManager) RevokeSelf(ctx context.Context, token string) {
-
-	err := m.client.Auth().Token().RevokeSelf(token)
-	if err != nil {
-		log.Errorf("failed to revoke self: %s", err)
-	} else {
-		log.Infof("revoked own token")
-	}
-
-}
-
-func (m *DefaultLeaseManager) RenewSecret(ctx context.Context, secret *api.Secret, lease time.Duration) error {
-	logger := log.WithField("leaseID", secret.LeaseID)
-	logger.Infof("renewing lease by %s.", lease)
-
-	op := func() error {
-		secret, err := m.client.Sys().Renew(secret.LeaseID, int(lease.Seconds()))
-		if err != nil {
-			logger.Errorf("error renewing lease: %s", err)
-			fatalError := checkFatalError(err)
-			if fatalError != nil {
-				return backoff.Permanent(fatalError)
-			}
-			return err
-		}
-		logger.WithFields(secretFields(secret)).Infof("successfully renewed secret")
-
-		return nil
-	}
-
-	err := backoff.Retry(op, backoff.WithContext(defaultRetryStrategy(lease), ctx))
-
-	return err
-}
-
-func NewLeaseManager(client *api.Client) CredentialsRenewer {
-	return &DefaultLeaseManager{client: client}
-}
-
-type DefaultCredentialsProvider struct {
-	client *api.Client
-	path   string
-}
-
-func NewCredentialsProvider(client *api.Client, secretPath string) *DefaultCredentialsProvider {
-	return &DefaultCredentialsProvider{client: client, path: secretPath}
-}
-
-func (c *DefaultCredentialsProvider) Fetch() (*Credentials, error) {
-	log.Infof("requesting credentials")
-	secret, err := c.client.Logical().Read(c.path)
-	if err != nil {
-		return nil, err
-	}
-
-	log.WithFields(secretFields(secret)).Infof("succesfully retrieved credentials")
-
-	return &Credentials{secret.Data["username"].(string), secret.Data["password"].(string), secret}, nil
 }
 
 type Credentials struct {
@@ -148,54 +59,6 @@ type KubernetesAuthConfig struct {
 	Role      string
 }
 
-// DefaultVaultClientFactory creates a Vault client
-// authenticated against a kubernetes service account
-// token
-type DefaultVaultClientFactory struct {
-	vault *VaultConfig
-	kube  *KubernetesAuthConfig
-}
-
-// Create returns a Vault client that has been authenticated
-// with the service account token. It can be used to make other
-// Vault requests
-func (f *DefaultVaultClientFactory) Create(tokenPath string) (*api.Client, *api.Secret, error) {
-	client, err := f.createUnauthenticatedClient()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var secret *api.Secret
-
-	//If the token file exists read that instead of generating a new auth token
-	if _, err = os.Stat(tokenPath); err == nil {
-		log.Info("detected existing vault token, using that")
-		secret, err = f.authRead(client, tokenPath)
-		if err != nil {
-			return nil, nil, err
-		}
-	} else {
-		secret, err = f.authenticate(client)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-
-	return client, secret, nil
-}
-
-func (f *DefaultVaultClientFactory) createUnauthenticatedClient() (*api.Client, error) {
-	cfg := api.DefaultConfig()
-	cfg.Address = f.vault.VaultAddr
-	cfg.ConfigureTLS(&api.TLSConfig{CACert: f.vault.TLS.CACert, CAPath: f.vault.TLS.CAPath})
-	client, err := api.NewClient(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	return client, nil
-}
-
 type login struct {
 	JWT  string `json:"jwt"`
 	Role string `json:"role"`
@@ -217,60 +80,6 @@ func secretFields(secret *api.Secret) log.Fields {
 	}
 
 	return fields
-}
-
-// Exchanges the kubernetes service account token for a vault token
-func (f *DefaultVaultClientFactory) authenticate(client *api.Client) (*api.Secret, error) {
-	bytes, err := ioutil.ReadFile(f.kube.TokenFile)
-	if err != nil {
-		return nil, fmt.Errorf("error reading token: %s", err)
-	}
-
-	req := client.NewRequest("POST", fmt.Sprintf("/v1/auth/%s", f.kube.LoginPath))
-	req.SetJSONBody(&login{JWT: string(bytes), Role: f.kube.Role})
-	resp, err := client.RawRequest(req)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.Error() != nil {
-		return nil, resp.Error()
-	}
-
-	var secret api.Secret
-	err = json.NewDecoder(resp.Body).Decode(&secret)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing response: %s", err)
-	}
-
-	logger := log.WithFields(secretFields(&secret))
-	logger.Infof("successfully authenticated")
-	client.SetToken(secret.Auth.ClientToken)
-
-	return &secret, nil
-}
-
-func (f *DefaultVaultClientFactory) authRead(client *api.Client, tokenPath string) (*api.Secret, error) {
-
-	var secret api.Secret
-
-	bytes, err := ioutil.ReadFile(tokenPath)
-	if err != nil {
-		log.Fatal("error reading token:", err)
-	}
-
-	err = yaml.Unmarshal(bytes, &secret)
-	if err != nil {
-		log.Fatal("error unmarshalling token")
-	}
-
-	client.SetToken(secret.Auth.ClientToken)
-
-	return &secret, nil
-}
-
-func NewKubernetesAuthClientFactory(vault *VaultConfig, kube *KubernetesAuthConfig) *DefaultVaultClientFactory {
-	return &DefaultVaultClientFactory{vault: vault, kube: kube}
 }
 
 func checkFatalError(err error) error {

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -20,8 +20,7 @@ type CredentialsProvider interface {
 }
 
 type CredentialsRenewer interface {
-	RenewSecret(ctx context.Context) error
-	RenewAuthToken(ctx context.Context) error
+	Renew(ctx context.Context) error
 	RevokeSelf(ctx context.Context)
 	Run(ctx context.Context, c chan int)
 }

--- a/pkg/vault/vault_test.go
+++ b/pkg/vault/vault_test.go
@@ -1,0 +1,23 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestFatalError(t *testing.T) {
+	err := checkFatalError(fmt.Errorf("Code: 403"))
+	if err != ErrPermissionDenied {
+		t.Errorf("error should be permission denied got: %v", err)
+	}
+
+	err = checkFatalError(fmt.Errorf("lease not found or lease is not renewable"))
+	if err != ErrLeaseNotFound {
+		t.Errorf("error should be lease not found got: %v", err)
+	}
+
+	err = checkFatalError(fmt.Errorf("foo"))
+	if err != nil {
+		t.Errorf("error should be nil got: %v", err)
+	}
+}


### PR DESCRIPTION
I've rewritten a lot of the code to clean it up a lot, I've moved all of the vault and kube logic out to packages instead of being in main, we've got things like the renewal loop and pod status checker running in their own go routines instead of a giant go func in main.  Broke up the giant vault.go to make it easier to understand. 

Also added a few very basic tests, I realised a lot of the functions are quite hard to test due to them being reliant on the vault api, but I've tested some of the more basic functions to start with. 