### PR TITLE
Fix for env variables with multiple equal signs

### DIFF
--- a/pkg/vault/credentials.go
+++ b/pkg/vault/credentials.go
@@ -40,7 +40,7 @@ func (c *Credentials) EnvVars() map[string]string {
 
 	for _, v := range os.Environ() {
 		splitEnv := strings.Split(v, "=")
-		envMap[splitEnv[0]] = splitEnv[1]
+		envMap[splitEnv[0]] = strings.Join(splitEnv[1:], "=")
 	}
 
 	// overwrites env variables called Username and Password


### PR DESCRIPTION
It could happen that environment variables contain more then one equal sign:
```
JDBC_URL=jdbc://hostname:port/dbname?ssl=true
```
In case the equal sign is not escaped it gets splitted and ignored, so the outcome is:
```
JDBC_URL=jdbc://hostname:port/dbname
```

In case your file is configured with:
```
JDBC_URL = {{ .JDBC_URL }}
```