### PR TITLE
Add check for nil secret

### DIFF
--- a/pkg/vault/manager.go
+++ b/pkg/vault/manager.go
@@ -154,7 +154,7 @@ func (m *DefaultManager) Save() error {
 
 func (m *DefaultManager) renewSecret(leaseID string) error {
 	secret, err := m.client.Sys().Renew(leaseID, int(m.lease.Seconds()))
-	if err != nil {
+	if err != nil || secret == nil {
 		log.Errorf("error renewing lease: %s", err)
 		fatalError := checkFatalError(err)
 		if fatalError != nil {
@@ -189,7 +189,7 @@ func (m *DefaultManager) renewCertificate() error {
 
 func renewAuth(client *api.Client, renew int) error {
 	secret, err := client.Auth().Token().RenewSelf(renew)
-	if err != nil {
+	if err != nil || secret == nil {
 		log.Errorf("error renewing token: %s", err)
 		fatalError := checkFatalError(err)
 		if fatalError != nil {

--- a/pkg/vault/manager.go
+++ b/pkg/vault/manager.go
@@ -155,6 +155,9 @@ func (m *DefaultManager) Save() error {
 func (m *DefaultManager) renewSecret(leaseID string) error {
 	secret, err := m.client.Sys().Renew(leaseID, int(m.lease.Seconds()))
 	if err != nil || secret == nil {
+		if err == nil {
+			err = fmt.Errorf("secret is nil")
+		}
 		log.Errorf("error renewing lease: %s", err)
 		fatalError := checkFatalError(err)
 		if fatalError != nil {
@@ -190,6 +193,9 @@ func (m *DefaultManager) renewCertificate() error {
 func renewAuth(client *api.Client, renew int) error {
 	secret, err := client.Auth().Token().RenewSelf(renew)
 	if err != nil || secret == nil {
+		if err == nil {
+			err = fmt.Errorf("secret is nil")
+		}
 		log.Errorf("error renewing token: %s", err)
 		fatalError := checkFatalError(err)
 		if fatalError != nil {

--- a/pkg/vault/providers.go
+++ b/pkg/vault/providers.go
@@ -49,7 +49,10 @@ func (c *VaultSecretsProvider) newCertificate() (*Certificate, error) {
 	}
 
 	secret, err := c.client.Logical().Write(c.path, params)
-	if err != nil {
+	if err != nil || secret == nil {
+		if err == nil {
+			return nil, fmt.Errorf("secret is nil")
+		}
 		return nil, err
 	}
 
@@ -73,7 +76,10 @@ func (c *VaultSecretsProvider) newCertificate() (*Certificate, error) {
 
 func (c *VaultSecretsProvider) newCredentials() (*Credentials, error) {
 	secret, err := c.client.Logical().Read(c.path)
-	if err != nil {
+	if err != nil || secret == nil {
+		if err == nil {
+			return nil, fmt.Errorf("secret is nil")
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
There was an error discovered where when trying to read the secret value, these were nil.
Seen [here](https://rv-u.slack.com/archives/CDNG5TYBX/p1606480191020900)

This means that both the error and secret were nil.

Looking in the vault code, there is a use case [here](https://github.com/hashicorp/vault/blob/master/api/secret.go#L311-L313) where both the error and secret can be returned as nil.

This change should retry the actions if secret is nil