### PR TITLE
fix typo on which file to modify access perms

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -44,7 +44,7 @@ jobs:
       with:
         images: quay.io/uswitch/vault-creds
         tags: |
-          type=semver,pattern={{version}}
+          type=semver,pattern=v{{version}}
           type=sha,prefix=,format=long,
     - uses: docker/build-push-action@v4
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ RUN apk add -U --no-cache ca-certificates
 
 FROM scratch
 
-ADD bin/vaultcreds /vaultcreds
+COPY --chmod=755 bin/vaultcreds /vaultcreds
 
-COPY --chmod=755 --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 ENTRYPOINT ["/vaultcreds"]
 CMD []


### PR DESCRIPTION
In previous PR I added `--chmod=755` to the wrong files here. It should be on the binary being copied into the image, not on the certs.

To be consistent with images we've published for this repo before, adding a `v` prefix to the image tags we publish.